### PR TITLE
A couple of improvements, hopefully.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ This role variables are namespaced using the `pip_config_` prefix.
 
 - `pip_config_dir`: the directory in which install pip's configuration
   file (default: `~/.pip/`);
-- `pip_config_extra_index_urls`: the list of extra PyPI index you want
-  pip to look for packages from (default: `[]`).
+- `pip_config_index_url`: the main PyPI index you want pip to look for
+  packages in (default: not defined);
+- `pip_config_extra_index_urls`: the list of extra PyPI indexes you want
+  pip to look for packages in (default: `[]`);
 - `pip_config_file`: the name to give to pip configuration file
   (default: `pip.conf`);
 - `pip_config_find_links_urls`: the list of extra web resources pip
@@ -39,6 +41,12 @@ The `pip_config_timeout` variable you may want to adjust depending on
 where are stored the packages you need. The lower the value, the less
 you wait, but the higher the risk of unexpected failures.
 
+If you want to add one or more PyPI indexes for pip to search in
+addition to the default one, specify them as a list value for
+`pip_config_extra_index_urls`.  If you want to override the default
+PyPI index entirely, specify your own main index as a string value for
+`pip_config_index_url`.  You can use both variables if you want pip
+to ignore the default index *and* search multiple other PyPI indexes.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,6 @@ pip_config_dir: "~/.pip"
 pip_config_index_url: ""
 pip_config_extra_index_urls: []
 pip_config_file: "pip.conf"
+pip_config_mode: 0400
 pip_config_find_links_urls: []
 pip_config_timeout: 10

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 pip_config_dir: "~/.pip"
+pip_config_index_url: ""
 pip_config_extra_index_urls: []
 pip_config_file: "pip.conf"
 pip_config_find_links_urls: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Ensure that PIP config directory exists
+  file:
+    path: "{{ pip_config_dir }}"
+    state: "directory"
+    recurse: "yes"
+
 - name: Install PIP config
   template:
     src: "pip.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,4 +9,4 @@
   template:
     src: "pip.conf"
     dest: "{{ pip_config_dir + '/' + pip_config_file }}"
-    mode: 0400
+    mode: {{ pip_config_mode }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,4 +9,4 @@
   template:
     src: "pip.conf"
     dest: "{{ pip_config_dir + '/' + pip_config_file }}"
-    mode: {{ pip_config_mode }}
+    mode: "{{ pip_config_mode }}"

--- a/templates/pip.conf
+++ b/templates/pip.conf
@@ -9,6 +9,10 @@ find-links =
 {% endfor %}
 {% endif %}
 
+{% if pip_config_index_url | length > 0 %}
+index-url = {{ pip_config_index_url }}
+{% endif %}
+
 {% if pip_config_extra_index_urls | length > 0 %}
 extra-index-url =
 {% for url in pip_config_extra_index_urls %}


### PR DESCRIPTION
Sometimes (for example, when using Artifactory's proxy repository feature) it is helpful to be able to configure the index url in the pip configuration.  This pull request adds this functionality.

This request also ensures that the configured directory in which to install the generated config file exists before trying to write the file into it.