### PR TITLE
fix: Correct invalid tags (closes #3).

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,7 +18,8 @@ galaxy_info:
 
   galaxy_tags:
     - 'pip'
-    - 'pip.conf'
+    - 'configuration'
+    - 'pypi'
     - 'python'
 
 dependencies: []


### PR DESCRIPTION
Ansible Galaxy tags cannot include characters like dot,
dash, *etc.* Only alpha-numeric characters are allowed.

Relevant documentation is https://galaxy.ansible.com/intro#tags.