### PR TITLE
Allow index url override

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -27,6 +27,20 @@ Fixed:
 
 * Fixed
 
+Version v1.1.0 -- 2018-05-08
+----------------------------
+
+Added:
+~~~~~~
+
+* Ability to override default index url. (from @stephenjolly)
+
+Fixed:
+~~~~~~
+
+* Improper use of expand user (closes #5)
+* Incorrect tags in role meta-data (closes #3)
+
 
 Version v1.0.0 -- 2018-04-07
 ----------------------------

--- a/Contributors
+++ b/Contributors
@@ -1,0 +1,1 @@
+@stephenjolly

--- a/README.md
+++ b/README.md
@@ -19,15 +19,14 @@ This role has the requirements of Ansible's
 Role Variables
 --------------
 
-This role variables are namespaced using the `pip_config_` prefix.
-
+This role variables are namespaced using the `pipconfig_` prefix.
 
 ### Default variables
 
 - `pipconfig_dir`: the directory in which install pip's configuration
-  file. Make sure it is in a safe place, see comment on `pip_config_dir`
+  file. Make sure it is in a safe place, see comment on `pipconfig_dir`
   item below. (default: `~/.pip/`);
-- `pipconfig_dir_mode`: the mode to set on the `pip_config_dir`
+- `pipconfig_dir_mode`: the mode to set on the `pipconfig_dir`
   directory. This it will contain a file that points you to different
   network locations, you should make to not leave yourself open to
   some misdirecting you by replacing its content with malicious one.
@@ -35,15 +34,15 @@ This role variables are namespaced using the `pip_config_` prefix.
   parents (defaults: 0500);
 - `pipconfig_file`: the name to give to pip configuration file
   (default: `pip.conf`);
-- `pipconfig_file_mode`: the mode to set on the `pip_config_file` file.
+- `pipconfig_file_mode`: the mode to set on the `pipconfig_file` file.
   Be mindful that you may need to put credentials in it. Tightening the
   permission is recommanded (default: 0400);
 - `pipconfig_timeout`: the duration in seconds pip will wait for any
   package index to respond before droping the connexion and try with
   the next (default: 10).
 
-You most likely do not need to modify the value of the `pip_config_file`
-variables. Same goes for `pip_config_file`, but since pip supports many
+You most likely do not need to modify the value of the `pipconfig_file`
+variables. Same goes for `pipconfig_dir`, but since pip supports many
 locations for its configuration, these allow you to do it if you fancy
 it. One such case is if you want to have different pip configurations
 for different Python [virtual environement](https://docs.python.org/3/library/venv.html).
@@ -55,15 +54,29 @@ you wait, but the higher the risk of unexpected failures.
 
 ### Input variables
 
-This are the variables you need to set for the role to actuall do
+These are the variables you need to set for the role to actually do
 something, useful:
 
+- `pipconfig_index_url`: the main PyPI index you want pip to look for
+  packages in (default: not defined);
 - `pipconfig_extra_index_urls`: the list of extra PyPI index you want
   pip to look for packages from (default: `[]`).
 - `pipconfig_find_links_urls`: the list of extra web resources pip
   should scan for links to Python packages (default: `[]`);
 
-You can define either or both of them.
+If you want to add one or more PyPI indexes for pip to search in
+addition to the default one, specify them as a list value for
+`pipconfig_extra_index_urls`.  If you want to override the default
+PyPI index entirely, specify your own main index as a string value for
+`pipconfig_index_url`.  You can use both variables if you want pip
+to ignore the default index *and* search multiple other PyPI indexes.
+
+The `pipconfig_find_links_urls` can be used to find packages from
+links in web pages and
+[local directories](https://pip.pypa.io/en/stable/user_guide/#installing-from-local-packages)
+(in which case you might need to pass Ansible's
+[pip module](http://docs.ansible.com/ansible/latest/modules/pip_module.html)
+some extra arguments).
 
 
 Dependencies
@@ -77,9 +90,9 @@ Example Playbook
 
     - hosts: servers
       vars:
-        pip_config_extra_index_urls:
+        pipconfig_extra_index_urls:
           - https://my-pypi.domain.com/simple
-        pip_config_find_links_urls:
+        pipconfig_find_links_urls:
           - https://my.domain.com/packages.html
 
       roles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,6 @@ pipconfig_extra_index_urls: []
 pipconfig_file: "pip.conf"
 pipconfig_file_mode: '0400'
 pipconfig_find_links_urls: []
+pipconfig_index_url: ""
 pipconfig_timeout: 10
+

--- a/templates/pip.conf
+++ b/templates/pip.conf
@@ -9,6 +9,10 @@ find-links =
 {% endfor %}
 {% endif %}
 
+{% if pipconfig_index_url %}
+index-url = {{ pipconfig_index_url }}
+{% endif %}
+
 {% if pipconfig_extra_index_urls | length > 0 %}
 extra-index-url =
 {% for url in pipconfig_extra_index_urls %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -41,6 +41,14 @@
       register: config_dir_check
       failed_when: 'config_dir_check is not success or config_dir_check.stat.mode != pipconfig_dir_mode'
 
+    - name: "Assert '{{pipconfig_file}}' does not contain index-url and url."
+      lineinfile:
+        path: "{{pipconfig_dir}}/{{ pipconfig_file }}"
+        line: "index-url = {{alt_index}}"
+        state: absent
+      register: findurl_lines_in_file_check
+      failed_when: "findurl_lines_in_file_check.changed"
+
     - name: "Assert '{{pipconfig_file}}' contains find-url and url."
       lineinfile:
         path: "{{pipconfig_dir}}/{{ pipconfig_file }}"
@@ -63,7 +71,7 @@
 
 
 - hosts: servers
-  name: "Ensure pipconfig_dir override is effective."
+  name: "Ensure overrides are effective."
   connection: local
   gather_facts: false
   vars_files:
@@ -95,6 +103,7 @@
 
   roles:
     - role: "pip-configure"
+      pipconfig_index_url: "{{ alt_index }}"
       pipconfig_find_links_urls: "{{ links }}"
       pipconfig_extra_index_urls: "{{ extras }}"
 
@@ -111,13 +120,21 @@
       register: config_dir_check
       failed_when: 'config_dir_check is not success or config_dir_check.stat.mode != pipconfig_dir_mode'
 
-    - name: "Assert '{{pipconfig_file}}' contains find-url and url."
+    - name: "Assert '{{pipconfig_file}}' contains index-url and url."
       lineinfile:
         path: "{{pipconfig_dir}}/{{ pipconfig_file }}"
-        line: "{{item.line}}"
+        line: "index-url = {{alt_index}}"
+        state: present
+      register: findurl_lines_in_file_check
+      failed_when: "findurl_lines_in_file_check.changed"
+
+    - name: "Assert '{{pipconfig_file}}' contains extra-index-url and url."
+      lineinfile:
+        path: "{{ pipconfig_dir }}/{{ pipconfig_file }}"
+        line: "{{ item.line }}"
         regexp: "{{ item.pattern |default(item.line) }}"
         state: present
-      with_items: "{{ [{'line': 'find-links =' }] + link_patterns }}"
+      with_items: "{{ [{'line': 'extra-index-url =' }] + extra_patterns }}"
       register: findurl_lines_in_file_check
       failed_when: "findurl_lines_in_file_check.changed"
 

--- a/tests/vars/all.yml
+++ b/tests/vars/all.yml
@@ -7,3 +7,4 @@ links:
   - 'https://s3.amazonaws.com/pypi.datadoghq.com/trace/index.html'
 extras:
   - 'https://pipy.example.com/simple'
+alt_index: "https://pypi.example.com/simple"


### PR DESCRIPTION
This is the part of #1 that had not been already implemented.

It allows to override the default Python Package Index to use altogether. That way pip to not hit `pypi.python.org` at all, if need be.